### PR TITLE
Switch deprecated ExCSS-core package in favor of ExCSS

### DIFF
--- a/VectSharp.SVG/VectSharp.SVG.csproj
+++ b/VectSharp.SVG/VectSharp.SVG.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ExCSS-Core" Version="4.0.5" />
+    <PackageReference Include="ExCSS" Version="4.1.3" />
     <PackageReference Include="VectSharp" Version="1.8.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Remove deprecated [ExCSS-core v4.0.5](https://www.nuget.org/packages/ExCSS-Core/) in favor of suggested alternative [ExCSS v4.1.3](https://www.nuget.org/packages/ExCSS/)