### PR TITLE
Add null checks for situations where added text is null or empty

### DIFF
--- a/VectSharp/Font.cs
+++ b/VectSharp/Font.cs
@@ -357,7 +357,8 @@ namespace VectSharp
         /// <returns>A <see cref="DetailedFontMetrics"/> object representing the metrics of the text.</returns>
         public DetailedFontMetrics MeasureTextAdvanced(string text)
         {
-            if (this.FontFamily.TrueTypeFile != null)
+       
+            if (this.FontFamily.TrueTypeFile != null && !string.IsNullOrWhiteSpace(text))
             {
                 double width = 0;
                 double yMin = 0;

--- a/VectSharp/GraphicsPath.cs
+++ b/VectSharp/GraphicsPath.cs
@@ -395,6 +395,11 @@ namespace VectSharp
             Point nextGlyphPlacementDelta = new Point();
             Point nextGlyphAdvanceDelta = new Point();
 
+            if (text == null)
+            {
+                return this;
+            }
+
             for (int i = 0; i < text.Length; i++)
             {
                 char c = text[i];


### PR DESCRIPTION
I experienced an issue where the library was throwing an nullreference exception when calling - after I had set the text to null.

`   var image = doc.Pages.Last().SaveAsImage();
`


`
vat text= null;
gpr.StrokeText(position, text, font, Colours.Black, lineJoin: LineJoins.Round);``
